### PR TITLE
[Fix] The way of getting testcases

### DIFF
--- a/test/.test/btn.test
+++ b/test/.test/btn.test
@@ -1,13 +1,15 @@
-add(tests, &tlen, (testcase) {
-   .name = "usual",
-   .argv = "10",
-   .input = "I hate programming in C so much.",
-   .output = "Ihateprogr\namminginCs\nomuch.\n"
-});
+TEST
+(
+   "usual",
+   "10",
+   "I hate programming in C so much.",
+   "Ihateprogr\namminginCs\nomuch.\n"
+)
 
-add(tests, &tlen, (testcase) {
-   .name = "multiline",
-   .argv = "10",
-   .input = "I hate programming in C so much.\nI'm getting headache.",
-   .output = "Ihateprogr\namminginCs\nomuch.I'mg\nettinghead\nache.\n"
-});
+TEST
+(
+   "multiline",
+   "10",
+   "I hate programming in C so much.\nI'm getting headache.",
+   "Ihateprogr\namminginCs\nomuch.I'mg\nettinghead\nache.\n"
+)

--- a/test/.test/btn.test
+++ b/test/.test/btn.test
@@ -1,9 +1,13 @@
-tests[0] = (testcase) { .name = "usual",
-                        .argv = "10",
-                        .input = "I hate programming in C so much.",
-                        .output = "Ihateprogr\namminginCs\nomuch.\n" };
-tests[1] = (testcase) { .name = "multiline",
-                        .argv = "10",
-                        .input = "I hate programming in C so much.\nI'm getting headache.",
-                        .output = "Ihateprogr\namminginCs\nomuch.I'mg\nettinghead\nache.\n" };
-tlen = 2;
+add(tests, &tlen, (testcase) {
+   .name = "usual",
+   .argv = "10",
+   .input = "I hate programming in C so much.",
+   .output = "Ihateprogr\namminginCs\nomuch.\n"
+});
+
+add(tests, &tlen, (testcase) {
+   .name = "multiline",
+   .argv = "10",
+   .input = "I hate programming in C so much.\nI'm getting headache.",
+   .output = "Ihateprogr\namminginCs\nomuch.I'mg\nettinghead\nache.\n"
+});

--- a/test/.test/hd.test
+++ b/test/.test/hd.test
@@ -1,27 +1,31 @@
-add(tests, &tlen, (testcase) {
-   .name = "no-heading",
-   .argv = "",
-   .input = "test",
-   .output = "# test\n"
-});
+TEST
+(
+   "no-heading",
+   "",
+   "test",
+   "# test\n"
+)
 
-add(tests, &tlen, (testcase) {
-   .name = "heading",
-   .argv = "",
-   .input = "# test",
-   .output = "# test\n"
-});
+TEST
+(
+   "heading",
+   "",
+   "# test",
+   "# test\n"
+)
 
-add(tests, &tlen, (testcase) {
-   .name = "no_heading_multiline",
-   .argv = "",
-   .input = "test\ntest2\n",
-   .output = "# test\n# test2\n\n"
-});
+TEST
+(
+   "no_heading_multiline",
+   "",
+   "test\ntest2\n",
+   "# test\n# test2\n\n"
+)
 
-add(tests, &tlen, (testcase) {
-   .name = "heading_multiline",
-   .argv = "",
-   .input = "# test\n# test2\n",
-   .output = "# test\n# test2\n\n"
-});
+TEST
+(
+   "heading_multiline",
+   "",
+   "# test\n# test2\n",
+   "# test\n# test2\n\n"
+)

--- a/test/.test/hd.test
+++ b/test/.test/hd.test
@@ -1,29 +1,27 @@
-tests[0] = (testcase)
-{
+add(tests, &tlen, (testcase) {
    .name = "no-heading",
    .argv = "",
    .input = "test",
    .output = "# test\n"
-};
-tests[1] = (testcase)
-{
+});
+
+add(tests, &tlen, (testcase) {
    .name = "heading",
    .argv = "",
    .input = "# test",
    .output = "# test\n"
-};
-tests[2] = (testcase)
-{
+});
+
+add(tests, &tlen, (testcase) {
    .name = "no_heading_multiline",
    .argv = "",
    .input = "test\ntest2\n",
    .output = "# test\n# test2\n\n"
-};
-tests[3] = (testcase)
-{
+});
+
+add(tests, &tlen, (testcase) {
    .name = "heading_multiline",
    .argv = "",
    .input = "# test\n# test2\n",
    .output = "# test\n# test2\n\n"
-};
-tlen = 4;
+});

--- a/test/.test/nsy.test
+++ b/test/.test/nsy.test
@@ -1,16 +1,20 @@
-tests[0] = (testcase) {
+add(tests, &tlen, (testcase) {
    .name = "e-mark",
    .argv = "e",
    .input = "asdf",
-   .output = "！a！s！d！f！\n"};
-tests[1] = (testcase) {
+   .output = "！a！s！d！f！\n"
+});
+
+add(tests, &tlen, (testcase) {
    .name = "q-mark",
    .argv = "q",
    .input = "asdf",
-   .output = "？a？s？d？f？\n" };
-tests[2] = (testcase) {
+   .output = "？a？s？d？f？\n"
+});
+
+add(tests, &tlen, (testcase) {
    .name = "multiline",
    .argv = "e",
    .input = "asdf\nqwer",
-   .output = "！a！s！d！f！q！w！e！r！\n" };
-tlen = 3;
+   .output = "！a！s！d！f！q！w！e！r！\n"
+});

--- a/test/.test/nsy.test
+++ b/test/.test/nsy.test
@@ -1,20 +1,23 @@
-add(tests, &tlen, (testcase) {
-   .name = "e-mark",
-   .argv = "e",
-   .input = "asdf",
-   .output = "！a！s！d！f！\n"
-});
+TEST
+(
+   "e-mark",
+   "e",
+   "asdf",
+   "！a！s！d！f！\n"
+)
 
-add(tests, &tlen, (testcase) {
-   .name = "q-mark",
-   .argv = "q",
-   .input = "asdf",
-   .output = "？a？s？d？f？\n"
-});
+TEST
+(
+   "q-mark",
+   "q",
+   "asdf",
+   "？a？s？d？f？\n"
+)
 
-add(tests, &tlen, (testcase) {
-   .name = "multiline",
-   .argv = "e",
-   .input = "asdf\nqwer",
-   .output = "！a！s！d！f！q！w！e！r！\n"
-});
+TEST
+(
+   "multiline",
+   "e",
+   "asdf\nqwer",
+   "！a！s！d！f！q！w！e！r！\n"
+)

--- a/test/README.md
+++ b/test/README.md
@@ -9,10 +9,10 @@ These programs require two things in order to run: (1) an executable of a progra
 A testcase file has test cases to be used during a test. It must have the following shape, since this file is to be included in a `test.c` source code file, which will be compiled soon.
 
 ```
-add(tests, &tlen, (testcase) { .name = "test 1", .argv = "...", .input = "...", .output = "..." });
-add(tests, &tlen, (testcase) { .name = "test 2", .argv = "...", .input = "...", .output = "..." });
+TEST("test-name-1", "argv", "input", "expected-output")
+TEST("test-name-2", "argv", "input", "expected-output")
 ...
-add(tests, &tlen, (testcase) { .name = "test n", .argv = "...", .input = "...", .output = "..." });
+TEST("test-name-n", "argv", "input", "expected-output")
 ```
 
 - name = the name of a test case.

--- a/test/README.md
+++ b/test/README.md
@@ -9,11 +9,10 @@ These programs require two things in order to run: (1) an executable of a progra
 A testcase file has test cases to be used during a test. It must have the following shape, since this file is to be included in a `test.c` source code file, which will be compiled soon.
 
 ```
-test[0] = (testcase) { .name = "", .argv = "", .input = "", .output = "" };
-test[1] = (testcase) { .name = "", .argv = "", .input = "", .output = "" };
+add(tests, &tlen, (testcase) { .name = "test 1", .argv = "...", .input = "...", .output = "..." });
+add(tests, &tlen, (testcase) { .name = "test 2", .argv = "...", .input = "...", .output = "..." });
 ...
-test[n] = (testcase) { .name = "", .argv = "", .input = "", .output = "" };
-tlen = n + 1;
+add(tests, &tlen, (testcase) { .name = "test n", .argv = "...", .input = "...", .output = "..." });
 ```
 
 - name = the name of a test case.

--- a/test/test.c
+++ b/test/test.c
@@ -9,7 +9,9 @@
 #define SYSTEM_FAILED   -1
 #
 #define TEST(_name, _argv, _input, _output) \
-   add(tests, &tlen, (testcase) { \
+   if (tlen == TESTCASE_LEN) \
+      raise_err("test: reached TESTCASE_LEN."); \
+   add(tests + (tlen++), (testcase) { \
       .name = _name, \
       .argv = _argv, \
       .input = _input, \
@@ -59,7 +61,7 @@ void raise_err(char *err_msg) {
    exit(EXIT_FAILURE);
 }
 
-void add(testcase *testcases, int *testcases_len_ptr, testcase testcase);
+void add(testcase *testcases, testcase testcase);
 
 /*
  * acquire_testcases
@@ -86,10 +88,8 @@ testcase *acquire_testcases(int *testcases_len_ptr) {
    return tests;
 }
 
-void add(testcase *testcases, int *testcases_len_ptr, testcase testcase) {
-   if (*testcases_len_ptr == TESTCASE_LEN)
-      raise_err("test: reached TESTCASE_LEN.");
-   testcases[(*testcases_len_ptr)++] = testcase;
+void add(testcase *testcases, testcase testcase) {
+   *testcases = testcase;
 }
 
 char *convert_linefeed(char *dest, char *replace_str, int len);

--- a/test/test.c
+++ b/test/test.c
@@ -11,12 +11,12 @@
 #define TEST(_name, _argv, _input, _output) \
    if (tlen == TESTCASE_LEN) \
       raise_err("test: reached TESTCASE_LEN."); \
-   add(tests + (tlen++), (testcase) { \
+   tests[tlen++] = (testcase) { \
       .name = _name, \
       .argv = _argv, \
       .input = _input, \
       .output = _output \
-   });
+   };
 
 typedef struct testcase_ {
    char *name;
@@ -86,10 +86,6 @@ testcase *acquire_testcases(int *testcases_len_ptr) {
 
    *testcases_len_ptr = tlen;
    return tests;
-}
-
-void add(testcase *testcases, testcase testcase) {
-   *testcases = testcase;
 }
 
 char *convert_linefeed(char *dest, char *replace_str, int len);

--- a/test/test.c
+++ b/test/test.c
@@ -7,6 +7,14 @@
 #define TESTCASE_LEN 32
 #define OUTPUT_LEN   1024
 #define SYSTEM_FAILED   -1
+#
+#define TEST(_name, _argv, _input, _output) \
+   add(tests, &tlen, (testcase) { \
+      .name = _name, \
+      .argv = _argv, \
+      .input = _input, \
+      .output = _output \
+   });
 
 typedef struct testcase_ {
    char *name;

--- a/test/test.c
+++ b/test/test.c
@@ -51,6 +51,8 @@ void raise_err(char *err_msg) {
    exit(EXIT_FAILURE);
 }
 
+void add(testcase *testcases, int *testcases_len_ptr, testcase testcase);
+
 /*
  * acquire_testcases
  * writes the length of testcases to the first argument
@@ -64,6 +66,7 @@ testcase *acquire_testcases(int *testcases_len_ptr) {
    tests = malloc(TESTCASE_LEN * sizeof(testcase));
    if (tests == NULL)
       raise_err("test: failed to malloc.");
+   tlen = 0;
    
    /*
     * Include test cases. This line will be replaced
@@ -73,6 +76,12 @@ testcase *acquire_testcases(int *testcases_len_ptr) {
 
    *testcases_len_ptr = tlen;
    return tests;
+}
+
+void add(testcase *testcases, int *testcases_len_ptr, testcase testcase) {
+   if (*testcases_len_ptr == TESTCASE_LEN)
+      raise_err("test: reached TESTCASE_LEN.");
+   testcases[(*testcases_len_ptr)++] = testcase;
 }
 
 char *convert_linefeed(char *dest, char *replace_str, int len);

--- a/test/test.c
+++ b/test/test.c
@@ -61,8 +61,6 @@ void raise_err(char *err_msg) {
    exit(EXIT_FAILURE);
 }
 
-void add(testcase *testcases, testcase testcase);
-
 /*
  * acquire_testcases
  * writes the length of testcases to the first argument


### PR DESCRIPTION
The current way is inconvenient and inherently dangerous: the program can't check whether a testcase is written within the memory block acquired from the `malloc()` call.