### PR TITLE
[Fix] Modify btn.c

### DIFF
--- a/btn/c/btn.c
+++ b/btn/c/btn.c
@@ -70,7 +70,8 @@ int main(int argc, char *argv[]) {
          }
       }
    }
-   putchar('\n');
+   if (printed_char_count != 0)
+      putchar('\n');
 
    return 0;
 }


### PR DESCRIPTION
Currently two `\n` will be printed if `printed_char_count == N`.