### PR TITLE
[Fix] LET THERE BE INLINE

### DIFF
--- a/nsy/c/nsy.c
+++ b/nsy/c/nsy.c
@@ -155,26 +155,26 @@ inline void print_ques_mark_u(void) {
 }
 
 /* . */
-void print_period(void) {
+inline void print_period(void) {
    putchar('.');  /* 0x002E */
 }
 
 /* ... */
-void print_ellipsis(void) {
+inline void print_ellipsis(void) {
    fputs("\xE2\x80\xA6", stdout);   /* 0x2026 */
 }
 
 /* + */
-void print_plus(void) {
+inline void print_plus(void) {
    putchar('+');  /* 0x002B */
 }
 
 /* ,, */
-void print_comma_twice(void) {
+inline void print_comma_twice(void) {
    fputs(",,", stdout);    /* 0x002C */
 }
 
 /* ♥ */
-void print_heart(void) {
+inline void print_heart(void) {
    fputs("\xE2\x99\xA5", stdout);    /* 0x2665 */
 }

--- a/nsy2/c/nsy2.c
+++ b/nsy2/c/nsy2.c
@@ -96,6 +96,6 @@ inline void print_ques_mark_u(void) {
 }
 
 /* ♥ */
-void print_heart(void) {
+inline void print_heart(void) {
    fputs("\xE2\x99\xA5", stdout);    /* 0x2665 */
 }


### PR DESCRIPTION
**Utils PR #43**

> In the 563db78 @logic-finder created nsy.c.
> In the 9db5beb @logic-finder created nsy2.c.
> And some functions in those files didn't have the inline definitions.
> And @logic-finder said, Let there be inline: and there was inline.
> And @logic-finder saw the inline, and it was good; and @logic-finder pushed the commit from the local to the remote.