### PR TITLE
[CI] Do not assume that bun is installed at $HOME.

### DIFF
--- a/.github/workflows/pr_javascript.yml
+++ b/.github/workflows/pr_javascript.yml
@@ -24,7 +24,7 @@ jobs:
         working-directory: ./test
     steps:
       - name: Build object program
-        run: ~/.bun/bin/bun build hd.js --compile --outfile hd
+        run: $BUN_INSTALL/bin/bun build hd.js --compile --outfile hd
         working-directory: ./hd/javascript
       - name: Build host program
         run: ./test_maker .test/hd.test

--- a/.github/workflows/push_javascript.yml
+++ b/.github/workflows/push_javascript.yml
@@ -21,7 +21,7 @@ jobs:
         run: gcc -o test_maker test_maker.c
 
       - name: Build object program
-        run: ~/.bun/bin/bun build hd.js --compile --outfile hd
+        run: $BUN_INSTALL/bin/bun build hd.js --compile --outfile hd
         working-directory: ./hd/javascript
       - name: Build host program
         run: ./test_maker .test/hd.test


### PR DESCRIPTION
This pull request updates the build steps in the GitHub Actions workflows for JavaScript to use the `BUN_INSTALL` environment variable for the `bun` binary path instead of a hardcoded path. This change improves portability and reliability of the workflows.

**Workflow improvements:**

* [`.github/workflows/pr_javascript.yml`](diffhunk://#diff-11b03859c167c4b876df35bf40ac41389c6c34d98a8ede7eef4335f8ff286851L27-R27): Changed the `bun` binary path in the "Build object program" step to use `$BUN_INSTALL/bin/bun` instead of `~/.bun/bin/bun`.
* [`.github/workflows/push_javascript.yml`](diffhunk://#diff-1df1323b289432148f15bce3bc7f8679d69e131132e7e6d608a7a0ad50215e94L24-R24): Changed the `bun` binary path in the "Build object program" step to use `$BUN_INSTALL/bin/bun` instead of `~/.bun/bin/bun`.