### PR TITLE
`hhss`에서 `argc`가 `2`가 아닐때 상냥한 오류메시지를 띄운다

### DIFF
--- a/hhss/c/hhss.c
+++ b/hhss/c/hhss.c
@@ -54,7 +54,7 @@ void free_str_arr(char **str_arr, int arr_len);
 
 int main(int argc, char *argv[]) {
    if (argc != 2)
-      raise_err("hhss: argc != 2.");
+      raise_err("usage: hhss <num>");
 
    FILE *hsr_dat = open_file(sentence_file, "r");
    FILE *usr_dat = open_file(user_file, "r");


### PR DESCRIPTION
것이다