### PR TITLE
`hhss`를 만들 때 데이터 파일의 "절대경로"를 전달하는 것이다

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ all_objects =
 $(foreach program,$(programs),$(eval $(call program_template,$(program))))
 
 # hhss.c requires a special care since it needs INSTPATH
-prefix := /usr/local
-datadir := $(prefix)/share/hhss
+inst_prefix := /usr/local
+datadir := $(inst_prefix)/share/hhss
 $(hhss_path)/hhss.o: $(hhss_path)/hhss.c
 	$(CC) $(CFLAGS) -DINSTPATH='"$(datadir)"' -o $@ -c $<
 
@@ -77,7 +77,7 @@ INSTALL := install
 INSTALL_PROGRAM := $(INSTALL)
 INSTALL_DATA := $(INSTALL) -m 644
 
-bindir := $(prefix)/bin
+bindir := $(inst_prefix)/bin
 hhss_data := hsr usr
 program_installation_cmd := $(INSTALL_PROGRAM) ./$$i/c/$$i $(bindir)
 data_installation_cmd := $(INSTALL_DATA) ./hhss/$$i $(datadir)

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ $(test_path)/test_maker: $(test_path)/test_maker.o
 
 .PHONY: uninstall
 uninstall:
-	rm -rf $(bindir)/$(programs)
+	rm -rf $(foreach program,$(programs),$(bindir)/$(program))
 	rm -rf $(datadir)
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ $(foreach program,$(programs),$(eval $(call program_template,$(program))))
 prefix := /usr/local
 datadir := $(prefix)/share/hhss
 $(hhss_path)/hhss.o: $(hhss_path)/hhss.c
-	$(CC) $(CFLAGS) -DINSTPATH='"$(datadir)/"' -o $@ -c $<
+	$(CC) $(CFLAGS) -DINSTPATH='"$(datadir)"' -o $@ -c $<
 ### THIS IS A VERY QUICK FIX AND NEEDS A LATER CARE ###
 
 ## Auxiliary Tasks

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ $(foreach program,$(programs),$(eval $(call program_template,$(program))))
 ### THIS IS A VERY QUICK FIX AND NEEDS A LATER CARE ###
 install_path := $(CURDIR)/bin
 datadir := $(install_path)/data
-hhss/c/hhss.o: hhss/c/hhss.c
-	$(CC) $(CFLAGS) -DINSTPATH='"$(datadir)/"' -c hhss/c/hhss.c -o hhss/c/hhss.o
+$(hhss_path)/hhss.o: $(hhss_path)/hhss.c
+	$(CC) $(CFLAGS) -DINSTPATH='"$(datadir)/"' -o $@ -c $<
 ### THIS IS A VERY QUICK FIX AND NEEDS A LATER CARE ###
 
 ## Auxiliary Tasks

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ $(foreach program,$(programs),$(eval $(call program_template,$(program))))
 install_path := $(CURDIR)/bin
 datadir := $(install_path)/data
 hhss/c/hhss.o: hhss/c/hhss.c
-	gcc -DINSTPATH='"$(datadir)/"' -c hhss/c/hhss.c -o hhss/c/hhss.o
+	$(CC) $(CFLAGS) -DINSTPATH='"$(datadir)/"' -c hhss/c/hhss.c -o hhss/c/hhss.o
 ### THIS IS A VERY QUICK FIX AND NEEDS A LATER CARE ###
 
 ## Auxiliary Tasks

--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ all_objects =
 $(foreach program,$(programs),$(eval $(call program_template,$(program))))
 
 ### THIS IS A VERY QUICK FIX AND NEEDS A LATER CARE ###
-install_path := $(CURDIR)/bin
-datadir := $(install_path)/data
+prefix := usr/local
+datadir := $(prefix)/share/hhss
 $(hhss_path)/hhss.o: $(hhss_path)/hhss.c
 	$(CC) $(CFLAGS) -DINSTPATH='"$(datadir)/"' -o $@ -c $<
 ### THIS IS A VERY QUICK FIX AND NEEDS A LATER CARE ###
@@ -78,7 +78,7 @@ INSTALL := install
 INSTALL_PROGRAM := $(INSTALL)
 INSTALL_DATA := $(INSTALL) -m 644
 
-bindir := $(install_path)
+bindir := $(prefix)/bin
 hhss_data := hsr usr
 program_installation_cmd := $(INSTALL_PROGRAM) ./$$i/c/$$i $(bindir)
 data_installation_cmd := $(INSTALL_DATA) ./hhss/$$i $(datadir)

--- a/Makefile
+++ b/Makefile
@@ -136,11 +136,11 @@ help:
 	@echo "	make		builds every program."
 	@echo "	make "$(call cmd_color,program-names...)
 	@echo " 			builds mentioned program(s) only, e.g. make btn nsy"
-	@echo "	make "$(call cmd_color,install)"	copies the executables of each program into ./bin directory."
+	@echo "	make "$(call cmd_color,install)"	copies the executables of each program into $(bindir) directory."
 	@echo
 	@echo $(call cmd_group,2. CLEANING ACTIONS)
 	@echo "	make "$(call cmd_color,clean)"	deletes all object files and all executables."
-	@echo "	make "$(call cmd_color,uninstall)"	deletes everything under ./bin directory."
+	@echo "	make "$(call cmd_color,uninstall)"	deletes everything under $(bindir) directory."
 	@echo "	make "$(call cmd_color,cleanall)"	clean + uninstall + some files in ./test"
 	@echo
 	@echo $(call cmd_group,3. MISCELLANEOUS)

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,8 @@ done
 endef
 
 install:
-	test -d $(install_path) || (mkdir $(bindir) && mkdir $(datadir))
+	test -d $(bindir) || (mkdir $(bindir))
+	test -d $(datadir) || (mkdir $(datadir))
 	$(call installation_template,$(programs),$(program_installation_cmd))
 	$(call installation_template,$(hhss_data:%=%.dat),$(data_installation_cmd))
 
@@ -113,7 +114,8 @@ $(test_path)/test_maker: $(test_path)/test_maker.o
 
 .PHONY: uninstall
 uninstall:
-	rm -rf $(install_path)
+	rm -rf $(bindir)/$(programs)
+	rm -rf $(datadir)
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,11 @@ all_objects =
 
 $(foreach program,$(programs),$(eval $(call program_template,$(program))))
 
-### THIS IS A VERY QUICK FIX AND NEEDS A LATER CARE ###
+# hhss.c requires a special care since it needs INSTPATH
 prefix := /usr/local
 datadir := $(prefix)/share/hhss
 $(hhss_path)/hhss.o: $(hhss_path)/hhss.c
 	$(CC) $(CFLAGS) -DINSTPATH='"$(datadir)"' -o $@ -c $<
-### THIS IS A VERY QUICK FIX AND NEEDS A LATER CARE ###
 
 ## Auxiliary Tasks
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -65,14 +65,20 @@ all_objects =
 
 $(foreach program,$(programs),$(eval $(call program_template,$(program))))
 
+### THIS IS A VERY QUICK FIX AND NEEDS A LATER CARE ###
+install_path := $(CURDIR)/bin
+datadir := $(install_path)/data
+hhss/c/hhss.o: hhss/c/hhss.c
+	gcc -DINSTPATH='"$(datadir)/"' -c hhss/c/hhss.c -o hhss/c/hhss.o
+### THIS IS A VERY QUICK FIX AND NEEDS A LATER CARE ###
+
 ## Auxiliary Tasks
 .PHONY: install
 INSTALL := install
 INSTALL_PROGRAM := $(INSTALL)
 INSTALL_DATA := $(INSTALL) -m 644
-install_path := ./bin
+
 bindir := $(install_path)
-datadir := $(install_path)/data
 hhss_data := hsr usr
 program_installation_cmd := $(INSTALL_PROGRAM) ./$$i/c/$$i $(bindir)
 data_installation_cmd := $(INSTALL_DATA) ./hhss/$$i $(datadir)

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ all_objects =
 $(foreach program,$(programs),$(eval $(call program_template,$(program))))
 
 ### THIS IS A VERY QUICK FIX AND NEEDS A LATER CARE ###
-prefix := usr/local
+prefix := /usr/local
 datadir := $(prefix)/share/hhss
 $(hhss_path)/hhss.o: $(hhss_path)/hhss.c
 	$(CC) $(CFLAGS) -DINSTPATH='"$(datadir)/"' -o $@ -c $<

--- a/hhss/c/hhss.c
+++ b/hhss/c/hhss.c
@@ -36,10 +36,14 @@
 #define MIN_USER_NUM    1
 #
 #define COMMENT         '#'
+#
+#ifndef INSTPATH
+#define INSTPATH   "../"    /* install path; given when built */
+#endif
 
 char *arg_num_sentence_to_print = "argv[1]";
-char *sentence_file = "hsr.dat";
-char *user_file = "usr.dat";
+char *sentence_file = INSTPATH "hsr.dat";
+char *user_file = INSTPATH "usr.dat";
 char *user_template = "${user}";
 
 void raise_err(char *err_msg, ...);

--- a/hhss/c/hhss.c
+++ b/hhss/c/hhss.c
@@ -42,8 +42,8 @@
 #endif
 
 char *arg_num_sentence_to_print = "argv[1]";
-char *sentence_file = INSTPATH "hsr.dat";
-char *user_file = INSTPATH "usr.dat";
+char *sentence_file = INSTPATH "/hsr.dat";
+char *user_file = INSTPATH "/usr.dat";
 char *user_template = "${user}";
 
 void raise_err(char *err_msg, ...);

--- a/hhss/c/hhss.c
+++ b/hhss/c/hhss.c
@@ -41,10 +41,10 @@
 #define INSTPATH   "../"    /* install path; given when built */
 #endif
 
-char *arg_num_sentence_to_print = "argv[1]";
-char *sentence_file = INSTPATH "/hsr.dat";
-char *user_file = INSTPATH "/usr.dat";
-char *user_template = "${user}";
+const char *arg_num_sentence_to_print = "argv[1]";
+const char *sentence_file = INSTPATH "/hsr.dat";
+const char *user_file = INSTPATH "/usr.dat";
+const char *user_template = "${user}";
 
 void raise_err(char *err_msg, ...);
 FILE *open_file(char *name, char *mode);


### PR DESCRIPTION
절대경로를 전달하지 않으면 `hsr.dat`과 `usr.dat`을 `fopen`할 수 없는 것이다!!!!!!!
매우 화나는 것이다!!!!!!!
그래서 빌드하는 과정에서 gcc를 호출할 때 `INSTPATH` 매크로를 정의하도록 한 것이다!!!
https://github.com/sdbx/Utils/blob/575e0adf7d897d3956a00c90d0fe70abd296ef6d/Makefile#L71-L72
급한대로 하드코딩하긴 했지만 봐주는 것이다!!!!!
그런 다음 hhss.c에서 해당 매크로를 사용하는 것이다!!!!
```c
#ifndef INSTPATH
#define INSTPATH   "../"    /* install path; given when built */
#endif

char *sentence_file = INSTPATH "hsr.dat";
char *user_file = INSTPATH "usr.dat";
```


것이다