### PR TITLE
github: add reviewer instructions for copilot

### DIFF
--- a/.github/workflows/instructions/review-c.instructions.md
+++ b/.github/workflows/instructions/review-c.instructions.md
@@ -2,18 +2,18 @@
 applyTo: "*/c/*"
 ---
 
-Here are the instructions for reviewing C code in this project.
+Use the following instructions when reviewing C code in this project.
 
-- Verify that the code follows `SPECIFICATION.md` and satisfies all functional requirements.
+- Verify that the code follows `SPECIFICATION.md` and meets all functional requirements.
 
-- Respect the existing code style and formatting. If you notice inconsistencies, point them out in your review.
+- Respect the existing code style and formatting. If you notice inconsistencies, call them out in your review.
 - Point out style or formatting issues that conflict with generally accepted C conventions, unless the current style clearly improves readability or maintainability.
 - Check for clear and descriptive naming of variables, functions, and types. Suggest improvements if names are ambiguous or misleading.
 - Point out any code that is difficult to understand or maintain, and suggest ways to improve clarity and readability.
-- Check whether the code follows standard C (for example, C89/C99) and common best practices.
-- Check whether the code can be compiled by a standard C compiler with warnings enabled, without warnings or errors.
+- Check whether the code follows standard C (for example, C89 or C99) and common best practices.
+- Check whether the code can be compiled by a standard C compiler with warnings enabled, with no warnings or errors.
 
-- Look for potential memory leaks, especially when using dynamic memory allocation (`malloc`, `calloc`, `realloc`).
+- Look for potential memory leaks, especially when dynamic memory allocation is used (`malloc`, `calloc`, `realloc`).
 - Ensure every owned resource is released on all paths (memory, file descriptors, and open `FILE*` handles).
 - Check error handling for library and system calls, including return value checks and clear failure behavior.
 - Look for potential buffer overflows, especially with functions such as `strcpy`, `strcat`, or `sprintf`. Suggest safer alternatives such as `snprintf`, bounded copies, and explicit length checks.
@@ -21,3 +21,5 @@ Here are the instructions for reviewing C code in this project.
 - Check array/string boundary handling for off-by-one errors and missing null terminators.
 - Check for integer overflow/underflow and risky signed/unsigned conversions in size, index, and length calculations.
 - Flag undefined behavior risks (for example: use-after-free, double free, out-of-bounds access, and uninitialized reads).
+
+- Finally, you may choose not to leave any comments if the code is already high quality and meets all of the criteria above.

--- a/.github/workflows/instructions/review-c.instructions.md
+++ b/.github/workflows/instructions/review-c.instructions.md
@@ -1,0 +1,19 @@
+Here are the instructions for reviewing C code in this project.
+
+- Verify that the code follows `SPECIFICATION.md` and satisfies all functional requirements.
+
+- Respect the existing code style and formatting. If you notice inconsistencies, point them out in your review.
+- Point out style or formatting issues that conflict with generally accepted C conventions, unless the current style clearly improves readability or maintainability.
+- Check for clear and descriptive naming of variables, functions, and types. Suggest improvements if names are ambiguous or misleading.
+- Point out any code that is difficult to understand or maintain, and suggest ways to improve clarity and readability.
+- Check whether the code follows standard C (for example, C89/C99) and common best practices.
+- Check whether the code can be compiled by a standard C compiler with warnings enabled, without warnings or errors.
+
+- Look for potential memory leaks, especially when using dynamic memory allocation (`malloc`, `calloc`, `realloc`).
+- Ensure every owned resource is released on all paths (memory, file descriptors, and open `FILE*` handles).
+- Check error handling for library and system calls, including return value checks and clear failure behavior.
+- Look for potential buffer overflows, especially with functions such as `strcpy`, `strcat`, or `sprintf`. Suggest safer alternatives such as `snprintf`, bounded copies, and explicit length checks.
+- Check pointer safety: initialization before use, null checks where needed, and no invalid dereferences.
+- Check array/string boundary handling for off-by-one errors and missing null terminators.
+- Check for integer overflow/underflow and risky signed/unsigned conversions in size, index, and length calculations.
+- Flag undefined behavior risks (for example: use-after-free, double free, out-of-bounds access, and uninitialized reads).

--- a/.github/workflows/instructions/review-c.instructions.md
+++ b/.github/workflows/instructions/review-c.instructions.md
@@ -1,3 +1,7 @@
+---
+applyTo: "*/c/*"
+---
+
 Here are the instructions for reviewing C code in this project.
 
 - Verify that the code follows `SPECIFICATION.md` and satisfies all functional requirements.

--- a/.github/workflows/instructions/review-c.instructions.md
+++ b/.github/workflows/instructions/review-c.instructions.md
@@ -22,4 +22,4 @@ Use the following instructions when reviewing C code in this project.
 - Check for integer overflow/underflow and risky signed/unsigned conversions in size, index, and length calculations.
 - Flag undefined behavior risks (for example: use-after-free, double free, out-of-bounds access, and uninitialized reads).
 
-- Finally, you may choose not to leave any comments if the code is already high quality and meets all of the criteria above.
+- Finally, you may choose not to leave any comments and approve the changes if the code is already high quality and meets all of the criteria above.


### PR DESCRIPTION
This pull request adds a new set of instructions for reviewing C code to the project. The instructions cover code style, correctness, memory safety, error handling, and best practices to help reviewers ensure high-quality C code submissions.

Documentation:

* Added `.github/workflows/instructions/review-c.instructions.md` with guidelines for reviewing C code, including checks for specification compliance, code style, naming, memory safety, error handling, and avoidance of common C pitfalls.