### PR TITLE
[Docs] Add manual pages for each program and the whole project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+## Includes
+include defs.mk
+
 ## Settings
 SHELL := /bin/sh
 CC := gcc
@@ -15,11 +18,12 @@ define cstr
 endef
 name_str = $(call cstr,38;5;49;1,$1)
 build_completed_str = $(call cstr,48;5;222;30, [ BUILD COMPLETED ] )
-installation_done_str = $(call cstr,48;5;150;30, [ INSTALLATION DONE ] )
-warning_str = $(call cstr,48;5;88;37, [ WARNING ] )
+inst_done_str = $(call cstr,48;5;150;30, [ INSTALL DONE ] )
+warn_str = $(call cstr,48;5;88;37, [ WARNING ] )
 notice_str = $(call cstr,48;5;152;30, [ NOTICE ] )
 
 ## Compilations
+project := Utils
 programs := btn hd hhss nsy nsy2 yandere
 _programs := $(foreach program,$(programs),./$(program)/c/$(program))
 default_goal := __record__
@@ -78,25 +82,23 @@ INSTALL_PROGRAM := $(INSTALL)
 INSTALL_DATA := $(INSTALL) -m 644
 
 bindir := $(inst_prefix)/bin
+man1dir := $(inst_prefix)/share/man/man1
+man7dir := $(inst_prefix)/share/man/man7
+
 hhss_data := hsr usr
+
 program_installation_cmd := $(INSTALL_PROGRAM) ./$$i/c/$$i $(bindir)
 data_installation_cmd := $(INSTALL_DATA) ./hhss/$$i $(datadir)
-
-define installation_template
-for i in $1; do \
-	if $2; then \
-		echo $(installation_done_str) $(call name_str,$$i) has been installed successfully.; \
-	else \
-		echo $(warning_str) There was a failure on installing $(call name_str,$$i).; \
-	fi \
-done
-endef
 
 install:
 	test -d $(bindir) || (mkdir $(bindir))
 	test -d $(datadir) || (mkdir $(datadir))
+	test -d $(man1dir) || (mkdir $(man1dir))
+	test -d $(man7dir) || (mkdir $(man7dir))
 	$(call installation_template,$(programs),$(program_installation_cmd))
 	$(call installation_template,$(hhss_data:%=%.dat),$(data_installation_cmd))
+	$(call inst_man_t,$(programs),$(INSTALL) -m 644 $$i/$$i.1 $(man1dir),1)
+	$(call inst_man_t,$(project),$(INSTALL) -m 644 $$i.7 $(man7dir),7)
 
 .PHONY: test
 test_path := ./test
@@ -113,8 +115,10 @@ $(test_path)/test_maker: $(test_path)/test_maker.o
 
 .PHONY: uninstall
 uninstall:
-	rm -rf $(foreach program,$(programs),$(bindir)/$(program))
+	rm -f $(foreach program,$(programs),$(bindir)/$(program))
 	rm -rf $(datadir)
+	rm -f $(foreach program,$(programs),$(man1dir)/$(program).1)
+	rm -f $(man7dir)/$(project).7
 
 .PHONY: clean
 clean:

--- a/Utils.7
+++ b/Utils.7
@@ -11,14 +11,14 @@ Utils - a collection of command line tools focused on producing weird strings
 \fByandere\fR - prints a yandere-like sentence ad infinitum
 .fi
 .SH DESCRIPTION
-This project provides command line tools all of which can assist the user to get the attention from other people by producing strings looking weird. Since the programs are implemented separately, the user can use the program as a standalone. However, these programs becomes more powerful when used together via pipeline.
+This project provides command line tools all of which can assist the user to get the attention from other people by producing strings looking weird. Since the programs are implemented separately, the user can use the program as a standalone. However, these programs become more powerful when used together via pipeline.
 .SH BUILD
-Since each program has several implementations developed in different langauges, one can choose which to use. Meanwhile, the project provides a central \fIMakefile\fR which builds a C implementation of each program. The following are part of available recipes:
+Since each program has several implementations developed in different languages, one can choose which to use. Meanwhile, the project provides a central \fIMakefile\fR which builds a C implementation of each program. The following are part of available recipes:
 .RS
 .sp
 .nf
 \fB$ make\fR - builds all programs (use C implementations)
-\fB$ make install\fR - installs executables under \fI/usr/local/bin\fR
+\fB$ make install\fR - installs executables under \fI/usr/local/bin\fR and manual pages
 \fB$ make uninstall\fR - removes the programs
 \fB$ make help\fR - prints a guide
 .fi

--- a/Utils.7
+++ b/Utils.7
@@ -1,0 +1,28 @@
+.TH Utils 7 2026-05-29 "Utils Project" "UTILS PROJECT"
+.SH NAME
+Utils - a collection of command line tools focused on producing weird strings
+.SH LIST OF PROGRAMS
+.nf
+\fBbtn\fR - removes whitespaces and makes a line break per a specified number of characters
+\fBhd\fR - makes <h1> headings
+\fBhhss\fR - prints arbitrary nonsenses
+\fBnsy\fR - inserts a specified character between every character in a string
+\fBnsy2\fR - inserts a specified character between every word in a string
+\fByandere\fR - prints a yandere-like sentence ad infinitum
+.fi
+.SH DESCRIPTION
+This project provides command line tools all of which can assist the user to get the attention from other people by producing strings looking weird. Since the programs are implemented separately, the user can use the program as a standalone. However, these programs becomes more powerful when used together via pipeline.
+.SH BUILD
+Since each program has several implementations developed in different langauges, one can choose which to use. Meanwhile, the project provides a central \fIMakefile\fR which builds a C implementation of each program. The following are part of available recipes:
+.RS
+.sp
+.nf
+\fB$ make\fR - builds all programs (use C implementations)
+\fB$ make install\fR - installs executables under \fI/usr/local/bin\fR
+\fB$ make uninstall\fR - removes the programs
+\fB$ make help\fR - prints a guide
+.fi
+.sp
+.RE
+.SH CONTRIBUTION
+Interested in this project? then please visit \fIhttps://github.com/sdbx/Utils\fR. This project accepts pull requests.

--- a/btn/btn.1
+++ b/btn/btn.1
@@ -1,0 +1,44 @@
+.TH btn 1 2026-05-28 "Utils Project" "UTILS PROJECT"
+.SH NAME
+btn - removes whitespaces and makes a line break per a specified number of characters
+.SH SYNOPSIS
+.nf
+\fBbtn\fR \fIN\fR
+\fBbtn\fR \fIN\fR < \fIFILE\fR
+.fi
+.PP
+※ \fIN\fR represents the number of characters before a line break character and must have a value between 1 and 32 (inclusive).
+.PP
+※ \fBbtn\fR uses \fBstdin\fR to take its input and writes the result on \fBstdout\fR.
+.SH DESCRIPTION
+\fBbtn\fR prints a long string having no white-space characters, given a text file from stdin. Thus a would-be attention seeker may find this program useful for his doing so-called buntangs, hence originated the program name \fBbtn\fR.
+.PP
+\[dq]Buntang\[dq] is a Korean word meaning disturbance or commotion; apparently it is used as a kind of the Internet slang nowadays to refer to such confusing misbehaviors themselves or the one who is exerting such dizziness-causing attitudes usually at online communities.
+.SH USAGE
+One can use \fBbtn\fR as a standalone program. However, it is when used in conjunction with other programs in the \fBUtils\fR project that \fBbtn\fR becomes so powerful.
+.SH EXAMPLE
+.B "＊ Use as a Standalone"
+.RS
+.sp
+$ btn 5 < nonsenses.txt
+.sp
+.RE
+.B "＊ Use in Conjunction with Other Utils Programs"
+.RS
+.sp
+$ hhss 5 | nsy e | btn 20
+.sp
+.RE
+This successive invocation of three programs--\fBhhss\fR, \fBnsy\fR, and \fBbtn\fR--gives a mind-blowing output which can be easily copied and pasted in the chating room in which one is.
+.SH COMMAND LINE ARGUMENTS
+.IP "[1] \fBN\fR"
+Determines the number of characters before a line break character. Must have a value on \fB[1, 32]\fR.
+.SH EXIT STATUS
+The current specification does not mention on the exit status. Thus, the exit status is implementation-defined as of now.
+.SH IMPLEMENTATIONS
+Currently, \fBbtn\fR has three implementations, which are all written in different languages.
+.SH CONTRIBUTORS
+Visit \fIhttps://github.com/sdbx/Utils/graphs/contributors\fR to see all the contributors!
+.SH UTILS PROJECT
+\fBbtn\fR is part of the \fBUtils\fR utility suite.
+For more information, please visit \fIhttps://github.com/sdbx/Utils\fR to browse the whole project.

--- a/btn/btn.1
+++ b/btn/btn.1
@@ -29,7 +29,7 @@ $ btn 5 < nonsenses.txt
 $ hhss 5 | nsy e | btn 20
 .sp
 .RE
-This successive invocation of three programs--\fBhhss\fR, \fBnsy\fR, and \fBbtn\fR--gives a mind-blowing output which can be easily copied and pasted in the chating room in which one is.
+This successive invocation of three programs--\fBhhss\fR, \fBnsy\fR, and \fBbtn\fR--gives a mind-blowing output which can be easily copied and pasted in the chatting room in which one is.
 .SH COMMAND LINE ARGUMENTS
 .IP "[1] \fBN\fR"
 Determines the number of characters before a line break character. Must have a value on \fB[1, 32]\fR.

--- a/defs.mk
+++ b/defs.mk
@@ -1,0 +1,23 @@
+define installation_template
+for i in $1; do \
+	if $2; then \
+		echo $(inst_done_str) $(call name_str,$$i) has been installed successfully.; \
+	else \
+		echo $(warn_str) There was a failure on installing $(call name_str,$$i).; \
+	fi \
+done
+endef
+
+# inst_man_t - manual install template
+# $1 = list of program names
+# $2 = install command
+# $3 = manual section
+define inst_man_t
+for i in $1; do \
+	if $2; then \
+		echo $(inst_done_str) $(call name_str,$$i.$3) has been installed.; \
+	else \
+		echo $(warn_str) Failed to install $(call name_str,$$i.$3).; \
+	fi \
+done
+endef

--- a/hd/hd.1
+++ b/hd/hd.1
@@ -1,0 +1,40 @@
+.TH hd 1 2026-05-28 "Utils Project" "UTILS PROJECT"
+.SH NAME
+hd - makes <h1> headings
+.SH SYNOPSIS
+.nf
+\fBhd\fR < \fIFILE\fR
+.fi
+.PP
+※ \fBhd\fR takes its input from \fBstdin\fR and prints the output on \fBstdout\fR.
+.SH DESCRIPTION
+\fBhd\fR puts a string \[dq]# \[dq] in front of the input and prints the result. Therefore, it is treated as a heading sentence in the Markdown syntax.
+.SH USAGE
+Since \fBhd\fR treats each line as a separate line, one can input-redirect a text file, which consists of multiple lines, to this program.
+.PP
+Considering such a behavior, one can exploit this property by pipelining this program with other programs in the \fBUtils\fR project.
+.SH EXAMPLE
+.B "＊ Input a File"
+.RS
+.sp
+$ hd < nonsenses.txt
+.sp
+.RE
+.B "＊ Use in Conjunction with Other Utils Programs"
+.RS
+.sp
+$ hhss 5 | hd
+.sp
+.RE
+This combination is remarkable in that it is not only easy to use, but also very effective to get attention from other participants in the chat room in which one is.
+.SH COMMAND LINE ARGUMENTS
+The current \fBhd\fR specification prescribes that a conforming implementation does not take any command line arguments.
+.SH EXIT STATUS
+The current specification does not mention on the exit status. Thus, the exit status is implementation-defined as of now.
+.SH IMPLEMENTATIONS
+Currently, \fBhd\fR has five implementations, which are all written in different languages.
+.SH CONTRIBUTORS
+Visit \fIhttps://github.com/sdbx/Utils/graphs/contributors\fR to see all the contributors!
+.SH UTILS PROJECT
+\fBhd\fR is part of the \fBUtils\fR utility suite.
+For more information, please visit \fIhttps://github.com/sdbx/Utils\fR to browse the whole project.

--- a/hhss/hhss.1
+++ b/hhss/hhss.1
@@ -1,0 +1,50 @@
+.TH hhss 1 2026-05-28 "Utils Project" "UTILS PROJECT"
+.SH NAME
+hhss - prints arbitrary nonsenses
+.SH SYNOPSIS
+.nf
+\fBhhss\fR \fIN\fR
+.fi
+.PP
+※ \fIN\fR determines the number of nonsenses to print and it must be equal to or greater than \fB5\fR.
+.SH DESCRIPTION
+\fBhhss\fR prints random nonsenses on \fBstdout\fR. Each nonsense is separated by a line break character.
+.PP
+This program uses two databases: \fIhsr.dat\fR and \fIusr.dat\fR. These files are under \fI/usr/local/share/hhss\fR. \fIhsr.dat\fR is a collection of nonsensical sentences. One can add new nonsenses by modifying the file. Incidentally, \fIusr.dat\fR is a collection of \[dq]user names\[dq]. When \fBhhss\fR reads a string from \fIhsr.dat\fR which contains one or more \[dq]{user}\[dq] substrings, the program replaces the substring with a user name found in \fIusr.dat\fR. One can add more names in the file as well.
+.SH USAGE
+The main strength of this program comes from its printing nonsenses. One can use this program as a standalone, but it is also possible to use it with other programs in the \fBUtils\fR project.
+.SH EXAMPLE
+.B "＊ Use as a Standalone"
+.RS
+.sp
+$ hhss 5
+.sp
+.RE
+.B "＊ Use in Conjunction with Other Utils Programs"
+.RS
+.sp
+$ hhss 5 | nsy e | hd
+.sp
+.RE
+With this combination, one can easily disturb the atmosphere of the chat room in which one is.
+.SH COMMAND LINE ARGUMENTS
+.IP "[1] \fBN\fR"
+Represents the number of nonsensical sentences to print out. Must be at least 5 and can't exceed the total number of sentences in the \fIhsr.dat\fR.
+.SH FILES
+.I hsr.dat
+.RS
+A database contaning nonsenses. Located at \fI/usr/local/share/hhss\fR.
+.RE
+.I usr.dat
+.RS
+A database contaning user names. Located at the same place with \fIhsr.dat\fR.
+.RE
+.SH EXIT STATUS
+The current specification does not mention on the exit status. Thus, the exit status is implementation-defined as of now.
+.SH IMPLEMENTATIONS
+Currently, \fBhhss\fR has four implementations, which are all written in different languages.
+.SH CONTRIBUTORS
+Visit \fIhttps://github.com/sdbx/Utils/graphs/contributors\fR to see all the contributors!
+.SH UTILS PROJECT
+\fBhhss\fR is part of the \fBUtils\fR utility suite.
+For more information, please visit \fIhttps://github.com/sdbx/Utils\fR to browse the whole project.

--- a/hhss/hhss.1
+++ b/hhss/hhss.1
@@ -33,11 +33,11 @@ Represents the number of nonsensical sentences to print out. Must be at least 5 
 .SH FILES
 .I hsr.dat
 .RS
-A database contaning nonsenses. Located at \fI/usr/local/share/hhss\fR.
+A database containing nonsenses. Located at \fI/usr/local/share/hhss\fR.
 .RE
 .I usr.dat
 .RS
-A database contaning user names. Located at the same place with \fIhsr.dat\fR.
+A database containing user names. Located at the same place with \fIhsr.dat\fR.
 .RE
 .SH EXIT STATUS
 The current specification does not mention on the exit status. Thus, the exit status is implementation-defined as of now.

--- a/nsy/nsy.1
+++ b/nsy/nsy.1
@@ -1,0 +1,66 @@
+.TH nsy 1 2026-05-28 "Utils Project" "UTILS PROJECT"
+.SH NAME
+nsy - inserts a specified character between every character in a string
+.SH SYNOPSIS
+.nf
+\fBnsy\fR \fI<mark>\fR
+\fBnsy\fR \fI<mark>\fR < \fI<file>\fR
+.fi
+.PP
+※ \fBnsy\fR takes its input from \fBstdin\fR and prints the output on \fBstdout\fR.
+.SH DESCRIPTION
+\fBnsy\fR places a specified delimiter between every character in a given sentence. \fI<mark>\fR, the sole command line argument, determines which delimiter to use.
+.USAGE
+The most noticeable characteristic of this program is that the output it produces looks extremely \[dq]noisy\[dq], hence originates the program name. In this reason, if one copied and pasted the result of this program into the chat room in which one is, it would be very easy to grab attention from the participants.
+.PP
+The difference between the \fBnsy2\fR program is that \fBnsy\fR places a delimiter between two characters while \fBnsy2\fR places between two words.
+.PP
+Indeed, this program can be used as a standalone, but it becomes more effective when used in conjunction with other programs in the \fBUtils\fR project.
+.SH EXAMPLE
+.B "＊ Use as a Standalone"
+.RS
+.sp
+$ nsy q < nonsenses.txt
+.sp
+.RE
+.B "＊ Use in Conjunction with Other Utils Programs"
+.RS
+.sp
+$ hhss 5 | nsy q | btn 20
+.sp
+.RE
+.SH COMMAND LINE ARGUMENTS
+.IP "[1] \fB<mark>\fR"
+Determines which delimiter to use. The standard delimiters which the current specification mandates are as the following:
+.RS
+.sp
+.nf
+\fBe\fR - exclamation mark
+\fBq\fR - question mark
+\fBeu\fR - exclamation mark, upside down
+\fBqu\fR - question mark, upside down
+.fi
+.sp
+.RE
+.SH NOTES
+An implementation may provide non-standard delimiters. For example, the current C implementation supports:
+.RS
+.sp
+.nf
+\fBp\fR - period
+\fBel\fR - ellipsis
+\fBpl\fR - plus
+\fBc\fR - comma printed twice
+\fBh\fR - heart
+.fi
+.sp
+.RE
+.SH EXIT STATUS
+The current specification does not mention on the exit status. Thus, the exit status is implementation-defined as of now.
+.SH IMPLEMENTATIONS
+Currently, \fBnsy\fR has four implementations, which are all written in different languages.
+.SH CONTRIBUTORS
+Visit \fIhttps://github.com/sdbx/Utils/graphs/contributors\fR to see all the contributors!
+.SH UTILS PROJECT
+\fBnsy\fR is part of the \fBUtils\fR utility suite.
+For more information, please visit \fIhttps://github.com/sdbx/Utils\fR to browse the whole project.

--- a/nsy/nsy.1
+++ b/nsy/nsy.1
@@ -47,11 +47,11 @@ An implementation may provide non-standard delimiters. For example, the current 
 .RS
 .sp
 .nf
+\fBc\fR - comma printed twice
+\fBh\fR - heart
 \fBp\fR - period
 \fBel\fR - ellipsis
 \fBpl\fR - plus
-\fBc\fR - comma printed twice
-\fBh\fR - heart
 .fi
 .sp
 .RE

--- a/nsy/nsy.1
+++ b/nsy/nsy.1
@@ -10,7 +10,7 @@ nsy - inserts a specified character between every character in a string
 ※ \fBnsy\fR takes its input from \fBstdin\fR and prints the output on \fBstdout\fR.
 .SH DESCRIPTION
 \fBnsy\fR places a specified delimiter between every character in a given sentence. \fI<mark>\fR, the sole command line argument, determines which delimiter to use.
-.USAGE
+.SH USAGE
 The most noticeable characteristic of this program is that the output it produces looks extremely \[dq]noisy\[dq], hence originates the program name. In this reason, if one copied and pasted the result of this program into the chat room in which one is, it would be very easy to grab attention from the participants.
 .PP
 The difference between the \fBnsy2\fR program is that \fBnsy\fR places a delimiter between two characters while \fBnsy2\fR places between two words.

--- a/nsy2/nsy2.1
+++ b/nsy2/nsy2.1
@@ -10,7 +10,7 @@ nsy2 - inserts a specified character between every word in a string
 ※ \fBnsy2\fR takes its input from \fBstdin\fR and prints the output on \fBstdout\fR.
 .SH DESCRIPTION
 \fBnsy2\fR places a specified delimiter between every word in a given sentence. \fI<mark>\fR, the sole command line argument, determines which delimiter to use.
-.USAGE
+.SH USAGE
 The most noticeable characteristic of this program is that the output it produces looks quite \[dq]noisy\[dq]. In this reason, if one copied and pasted the result of this program into the chat room in which one is, it would be very easy to grab attention from the participants.
 .PP
 The difference between the \fBnsy\fR program is that \fBnsy2\fR places a delimiter between two words while \fBnsy\fR places between two characters.

--- a/nsy2/nsy2.1
+++ b/nsy2/nsy2.1
@@ -1,0 +1,55 @@
+.TH nsy2 1 2026-05-28 "Utils Project" "UTILS PROJECT"
+.SH NAME
+nsy2 - inserts a specified character between every word in a string
+.SH SYNOPSIS
+.nf
+\fBnsy2\fR \fI<mark>\fR
+\fBnsy2\fR \fI<mark>\fR < \fI<file>\fR
+.fi
+.PP
+※ \fBnsy2\fR takes its input from \fBstdin\fR and prints the output on \fBstdout\fR.
+.SH DESCRIPTION
+\fBnsy2\fR places a specified delimiter between every word in a given sentence. \fI<mark>\fR, the sole command line argument, determines which delimiter to use.
+.USAGE
+The most noticeable characteristic of this program is that the output it produces looks quite \[dq]noisy\[dq]. In this reason, if one copied and pasted the result of this program into the chat room in which one is, it would be very easy to grab attention from the participants.
+.PP
+The difference between the \fBnsy\fR program is that \fBnsy2\fR places a delimiter between two words while \fBnsy\fR places between two characters.
+.PP
+Indeed, this program can be used as a standalone, but it becomes more effective when used in conjunction with other programs in the \fBUtils\fR project.
+.SH EXAMPLE
+.B "＊ Use as a Standalone"
+.RS
+.sp
+$ nsy2 q < nonsenses.txt
+.sp
+.RE
+.B "＊ Use in Conjunction with Other Utils Programs"
+.RS
+.sp
+$ hhss 5 | nsy2 q | btn 20
+.sp
+.RE
+.SH COMMAND LINE ARGUMENTS
+.IP "[1] \fB<mark>\fR"
+Determines which delimiter to use. The standard delimiters which the current specification mandates are as the following:
+.RS
+.sp
+.nf
+\fBe\fR - exclamation mark
+\fBq\fR - question mark
+\fBeu\fR - exclamation mark, upside down
+\fBqu\fR - question mark, upside down
+.fi
+.sp
+.RE
+.SH NOTES
+An implementation may provide non-standard delimiters. For example, the current C implementation supports \fBh\fR (heart).
+.SH EXIT STATUS
+The current specification does not mention on the exit status. Thus, the exit status is implementation-defined as of now.
+.SH IMPLEMENTATIONS
+Currently, \fBnsy2\fR has only one implementation.
+.SH CONTRIBUTORS
+Visit \fIhttps://github.com/sdbx/Utils/graphs/contributors\fR to see all the contributors!
+.SH UTILS PROJECT
+\fBnsy2\fR is part of the \fBUtils\fR utility suite.
+For more information, please visit \fIhttps://github.com/sdbx/Utils\fR to browse the whole project.

--- a/yandere/yandere.1
+++ b/yandere/yandere.1
@@ -1,0 +1,31 @@
+.TH yandere 1 2026-05-28 "Utils Project" "UTILS PROJECT"
+.SH NAME
+yandere - prints a yandere-like sentence ad infinitum
+.SH SYNOPSIS
+.nf
+\fByandere\fR
+.fi
+.SH DESCRIPTION
+\fByandere\fR writes a yandere-like string on \fBstdout\fR until the program termination.
+.SH USAGE
+Execute the program and see the console window getting covered with yandere-like strings!
+.SH EXAMPLE
+.B "＊ Appreciating an implementation"
+.RS
+.sp
+$ yandere
+.sp
+.RE
+.B "＊ Terminates the Program"
+.RS
+In order to terminate the program, one can press \[dq]\fBCtrl+C\fR\[dq] or invoke \[dq]\fBkill -9 $(pidof yandere)\fR\[dq].
+.RE
+.SH EXIT STATUS
+The current specification does not mention on the exit status. Thus, the exit status is implementation-defined as of now.
+.SH IMPLEMENTATIONS
+Currently, \fByandere\fR has two implementations, which are all written in different languages.
+.SH CONTRIBUTORS
+Visit \fIhttps://github.com/sdbx/Utils/graphs/contributors\fR to see all the contributors!
+.SH UTILS PROJECT
+\fByandere\fR is part of the \fBUtils\fR utility suite.
+For more information, please visit \fIhttps://github.com/sdbx/Utils\fR to browse the whole project.


### PR DESCRIPTION
## 요약
- 각 프로그램별로 매뉴얼 작성 (각 프로젝트 폴더 내에 위치)
- 전체 프로젝트에 대한 매뉴얼 작성 (프로젝트 루트에 위치)
- `make install`시
  - `/usr/local/share/man/man1` 아래에 `(프로그램명).1` 설치
  - `(동일경로)/man7` 에 `Utils.7` 설치

closes #64.