### PR TITLE
ci: run only related tests

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -4,6 +4,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - ".github/workflows/c.yml"
+      - "test/*"
+      - "*/c/*"
 
 jobs:
   test:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -4,6 +4,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - ".github/workflows/cpp.yml"
+      - "test/*"
+      - "*/cpp/*"
 
 jobs:
   test:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -4,6 +4,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - ".github/workflows/haskell.yml"
+      - "test/*"
+      - "*/haskell/*"
 
 jobs:
   test:

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -4,6 +4,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - ".github/workflows/javascript.yml"
+      - "test/*"
+      - "*/javascript/*"
 
 jobs:
   test:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -4,6 +4,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - ".github/workflows/python.yml"
+      - "test/*"
+      - "*/python/*"
 
 jobs:
   test:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - ".github/workflows/rust.yml"
+      - "test/*"
+      - "*/rust/*"
 
 jobs:
   test:


### PR DESCRIPTION
This pull request updates the workflow trigger conditions for several language-specific GitHub Actions workflows. Now, the workflows for C, C++, Haskell, JavaScript, Python, and Rust will only run on pull requests that modify relevant workflow files, test files, or language-specific directories. This change helps reduce unnecessary workflow runs and improves CI efficiency.

Workflow trigger updates:

* Updated `pull_request` triggers in the following workflow files to only run when relevant files or directories are changed:
  - `.github/workflows/c.yml`
  - `.github/workflows/cpp.yml`
  - `.github/workflows/haskell.yml`
  - `.github/workflows/javascript.yml`
  - `.github/workflows/python.yml`
  - `.github/workflows/rust.yml`