### PR TITLE
hotfix: rewrite rand_range logic

### DIFF
--- a/hhss/c/prelex.c
+++ b/hhss/c/prelex.c
@@ -10,7 +10,7 @@ extern array_t *prelex(array_t *db, int datcnt) {
    lastpos = array_size(db);
 
    for (int k = 0; k < datcnt; k++) {
-      rv = rand_range(0, lastpos);  /* [0, lp) */
+      rv = rand_range(0, lastpos - 1);  /* [0, lp - 1] */
 
       curr = array_get(db, rv);
       last = array_get(db, lastpos - 1);

--- a/hhss/c/replace.c
+++ b/hhss/c/replace.c
@@ -27,7 +27,7 @@ extern void replace_templates(array_t *pts, array_t *rtdb) {
          if (rtslen == 0)
             synerr_empty();
 
-         v = rand_range(0, rtslen);
+         v = rand_range(0, rtslen - 1);
          rt = *((char **) array_get(rts, v));
 
          sectarr = rtdbquery(rtdb, rt);
@@ -80,9 +80,8 @@ static void rthandle_user(symbol_t *sym, array_t *sectarr) {
       goto common;
    }
 
-   do {
-      r = rand_range(0, siz);
-   } while (r == pre_user);
+   do r = rand_range(0, siz - 1);
+   while (r == pre_user);
    pre_user = r;
 
    common:
@@ -93,7 +92,7 @@ static void rthandle_else(symbol_t *sym, array_t *sectarr) {
    int r, siz;
 
    siz = array_size(sectarr);
-   r = rand_range(0, siz);
+   r = rand_range(0, siz - 1);
    rthandle_common(sym, sectarr, r);
 }
 

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -5,10 +5,40 @@ extern void seed(void) {
    srand(time(NULL));
 }
 
+/* Refer to https://c-faq.com/lib/randrange.html */
 extern int rand_range(int min, int max) {
-   if (max <= 0)
-      VERR("max must be greater than 0, but given %d", max);
-   return min + rand() / (RAND_MAX / max + 1);
+   if (min >= max)
+      ERR("min should be less than max.");
+
+   unsigned long nbucket;  /* number of buckets */
+   unsigned int bucket_siz, threshold, rv;
+
+   /* since range is long, it's safe if max and min
+      were INT_MAX and INT_MIN, respectively */
+   nbucket = 1UL + max - min;
+   /* since rand() returns [0,RAND_MAX], the number of total
+      possible return values is RAND_MAX + 1 */
+   /* specify 'u' in order to treat it as a unsigned int value */
+   bucket_siz = (RAND_MAX + 1UL) / nbucket;
+   threshold = bucket_siz * nbucket;
+
+   do rv = rand();
+   while (rv >= threshold);
+
+   return min + (int) (rv / bucket_siz);
+
+   /* An example simulation.
+      Suppose RAND_MAX = 10, nbucket = 3.
+      Since bucket_siz = (10 + 1) / 3 = 3,
+      threshold = 3 * 3 = 9.
+      Since RAND_MAX is 10, rand() returns [0,10].
+      If rand returns 9 or 10, re-roll.
+      If rand returns 0 ~ 8, then
+         rv = 0,1,2 => rv / 3 = 0
+         rv = 3,4,5 => rv / 3 = 1
+         rv = 6,7,8 => rv / 3 = 2
+      Thus, all numbers (min ~ max) have an equal
+      possibility to appear. */
 }
 
 extern int mblen_(char ch) {

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -28,7 +28,7 @@ extern int rand_range(int min, int max) {
       rv;
 
    /* like there are 5 numbers in [1,5] since 5 - 1 + 1 = 5,
-      max - min + 1 means the count of the numbers in [max, min] */
+      max - min + 1 means the count of the numbers in [min, max] */
    /* since max - min <= RAND_MAX <= INT_MAX, it's fine to add 1 */
    nbucket = 1U + max - min;
    /* since rand() returns [0,RAND_MAX], the number of total

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -16,7 +16,7 @@ extern int rand_range(int min, int max) {
    if ((unsigned int) max - min > RAND_MAX)
       VERR("range too large to handle!"
          " max - min must be <= %d (RAND_MAX),"
-         " but given min=%d, max=%d", min, max);
+         " but given min=%d, max=%d", RAND_MAX, min, max);
 
    if (min == max)
       return min;

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -8,21 +8,34 @@ extern void seed(void) {
 /* Refer to https://c-faq.com/lib/randrange.html */
 extern int rand_range(int min, int max) {
    if (min > max)
-      ERR("min should be less than max.");
+      VERR("min must be less than or equal to max,"
+         " but given min=%d, max=%d", min, max);
+
+   /* implicit integer promotion happens */
+   /* INT_MAX - INT_MIN == UINT_MAX */
+   if ((unsigned int) max - min > RAND_MAX)
+      VERR("range too large to handle!"
+         " max - min must <= %d (RAND_MAX),"
+         " but given min=%d, max=%d", min, max);
 
    if (min == max)
       return min;
 
-   unsigned long nbucket;  /* number of buckets */
-   unsigned int bucket_siz, threshold, rv;
+   unsigned int
+      nbucket,  /* number of buckets */
+      bucket_siz,
+      threshold,
+      rv;
 
-   /* since range is long, it's safe if max and min
-      were INT_MAX and INT_MIN, respectively */
-   nbucket = 1UL + max - min;
+   /* like there are 5 numbers in [1,5] since 5 - 1 + 1 = 5,
+      max - min + 1 means the count of the numbers in [max, min] */
+   /* since max - min <= RAND_MAX <= INT_MAX, it's fine to add 1 */
+   nbucket = 1U + max - min;
    /* since rand() returns [0,RAND_MAX], the number of total
-      possible return values is RAND_MAX + 1 */
-   /* specify 'u' in order to treat it as a unsigned int value */
-   bucket_siz = (RAND_MAX + 1UL) / nbucket;
+      possible return values is RAND_MAX - 0 + 1 */
+   /* specify 'U' in order to treat it as a unsigned int value */
+   /* integer promotion also happens */
+   bucket_siz = (RAND_MAX + 1U) / nbucket;
    threshold = bucket_siz * nbucket;
 
    do rv = rand();
@@ -30,9 +43,9 @@ extern int rand_range(int min, int max) {
 
    return min + (int) (rv / bucket_siz);
 
-   /* An example simulation.
+   /* EXAMPLE CASE
       Suppose RAND_MAX = 10, nbucket = 3.
-      Since bucket_siz = (10 + 1) / 3 = 3,
+      Since bucket_siz = (10 + 1) / 3 = 3 (fractional part discarded),
       threshold = 3 * 3 = 9.
       Since RAND_MAX is 10, rand() returns [0,10].
       If rand returns 9 or 10, re-roll.
@@ -40,7 +53,7 @@ extern int rand_range(int min, int max) {
          rv = 0,1,2 => rv / 3 = 0
          rv = 3,4,5 => rv / 3 = 1
          rv = 6,7,8 => rv / 3 = 2
-      Thus, all numbers (min ~ max) have an equal
+      Thus, all numbers in [min, max] have an equal
       possibility to appear. */
 }
 

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -7,8 +7,11 @@ extern void seed(void) {
 
 /* Refer to https://c-faq.com/lib/randrange.html */
 extern int rand_range(int min, int max) {
-   if (min >= max)
+   if (min > max)
       ERR("min should be less than max.");
+
+   if (min == max)
+      return min;
 
    unsigned long nbucket;  /* number of buckets */
    unsigned int bucket_siz, threshold, rv;

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -15,7 +15,7 @@ extern int rand_range(int min, int max) {
    /* INT_MAX - INT_MIN == UINT_MAX */
    if ((unsigned int) max - min > RAND_MAX)
       VERR("range too large to handle!"
-         " max - min must <= %d (RAND_MAX),"
+         " max - min must be <= %d (RAND_MAX),"
          " but given min=%d, max=%d", min, max);
 
    if (min == max)

--- a/yandere/c/noise.c
+++ b/yandere/c/noise.c
@@ -6,13 +6,13 @@ extern void noise(const char *msg) {
    bool overflow;
 
    for (i = k = 0; msg[i] != '\0'; /* empty */) {
-      rv = rand_range(0, 6);
+      rv = rand_range(0, 5);
       chlen = mblen_(msg[i]);
       overflow = (k + chlen) >= (BUFMAX - 1);
 
       if (overflow) break;
       if (rv == 0) {   /* 1/6 chance */
-         buf[k++] = *("#?@" + rand_range(0, 3));
+         buf[k++] = *("#?@" + rand_range(0, 2));
          i += chlen;
       }
       else for (int m = 0; m < chlen; m++)


### PR DESCRIPTION
For example, The current `rand_range(0,6)` returns a value between [0,5]. However, this result is confusing in that it contradicts the function name.

Also, the current implementation seems to make an implicit expectation that `min` should be zero and `max` should be greater than zero. This also contradicts the function name.

From these reasons, I've modified the logic of the function and its usage across the files.