### PR TITLE
feat: introduce a new replace template syntax ${*}

### DIFF
--- a/hhss/c/global.h
+++ b/hhss/c/global.h
@@ -20,5 +20,8 @@
 #define OLD_RPTP_DB_NAME "/usr.dat"
 #define OLD_DATA_DB_PATH INSTPATH OLD_DATA_DB_NAME
 #define OLD_RPTP_DB_PATH INSTPATH OLD_RPTP_DB_NAME
+#
+#define SECTNAME_WILDCARD "*"
+#define SECTNAME_USER     "user"
 
 #endif

--- a/hhss/c/replace.c
+++ b/hhss/c/replace.c
@@ -6,6 +6,7 @@ extern void replace_templates(array_t *pts, array_t *rtdb) {
    symbol_t *sym;
    size_t ptslen, ptlen, rtslen;
    char *rt;
+   const char *sectname;
    int v;
 
    pre_user = -1;
@@ -18,26 +19,37 @@ extern void replace_templates(array_t *pts, array_t *rtdb) {
       for (size_t symidx = 0; symidx < ptlen; symidx++) {
          sym = array_get(pt, symidx);
 
-         if (sym->kind == SymkindText)
-            continue;
+         if (sym->kind != SymkindRepl)
+            continue;  /* only handle replace templates */
 
          rts = parse_replace_string(sym->content);
          rtslen = array_size(rts);
 
-         if (rtslen == 0)
+         if (!rtslen)
             synerr_empty();
 
          v = rand_range(0, rtslen - 1);
          rt = *((char **) array_get(rts, v));
 
-         sectarr = rtdbquery(rtdb, rt);
-         if (!sectarr)
-            synerr_invalid(rt);
+         if (STREQL(rt, SECTNAME_WILDCARD)) {  /* wildcard template? */
+            v = rand_range(0, array_size(rtdb) - 1);
+            sectarr = rtdbquerybyidx(rtdb, v, &sectname);
 
-         if (STREQL(rt, "user"))
-            rthandle_user(sym, sectarr);
-         else
-            rthandle_else(sym, sectarr);
+            if (STREQL(sectname, SECTNAME_USER))
+               rthandle_user(sym, sectarr);
+            else
+               rthandle_else(sym, sectarr);
+         }
+         else {
+            sectarr = rtdbquery(rtdb, rt);
+            if (!sectarr)
+               synerr_invalid(rt);
+
+            if (STREQL(rt, SECTNAME_USER))
+               rthandle_user(sym, sectarr);
+            else
+               rthandle_else(sym, sectarr);
+         }
 
          /* cleanup rts */
          for (size_t i = 0; i < rtslen; i++) {

--- a/hhss/c/replace.internals.h
+++ b/hhss/c/replace.internals.h
@@ -9,6 +9,7 @@
 #include "utils.h"
 #include "parse.h"
 #include "fatal.h"
+#include "global.h"
 #include "strutils.h"
 #include "wrappers.h"
 #include "rtdbparse.h"

--- a/hhss/c/rtdbparse.c
+++ b/hhss/c/rtdbparse.c
@@ -44,7 +44,7 @@ extern array_t *rtdbquery(array_t *table, const char *sectname) {
 
 extern array_t *rtdbquerybyidx(array_t *table, size_t idx, const char **sectname) {
    mapper_t *mapper = array_get(table, idx);
-   *sectname = mapper->sect;
+   if (sectname) *sectname = mapper->sect;
    return mapper->addr;
 }
 

--- a/hhss/c/rtdbparse.c
+++ b/hhss/c/rtdbparse.c
@@ -13,7 +13,7 @@ extern array_t *rtdbparse(array_t *linestr) {
    if (!setjmp(env)) {
       /* backward compatibility for usr.dat */
       if (!seek_section()) {
-         sectarr = add_mapper(table, "user");
+         sectarr = add_mapper(table, SECTNAME_USER);
          while (parse_value(sectarr));
       }
 
@@ -42,6 +42,12 @@ extern array_t *rtdbquery(array_t *table, const char *sectname) {
    return NULL;
 }
 
+extern array_t *rtdbquerybyidx(array_t *table, size_t idx, const char **sectname) {
+   mapper_t *mapper = array_get(table, idx);
+   *sectname = mapper->sect;
+   return mapper->addr;
+}
+
 extern void rtdbcheck(array_t *db) {
    mapper_t *m;
    array_t *sectarr;
@@ -57,7 +63,7 @@ extern void rtdbcheck(array_t *db) {
       sectname = m->sect;
       sectarr_siz = array_size(sectarr);
 
-      if (STREQL(sectname, "user")) {
+      if (STREQL(sectname, SECTNAME_USER)) {
          if (sectarr_siz >= threshold)
             continue;
          VERR("at least %zu user entries required but only %zu",
@@ -116,6 +122,8 @@ static int seek_section(void) {
 }
 
 static char *parse_section(void) {
+   char *ret;
+
    find_rearpos();
 
    if (l->run[rearpos] != ']') {
@@ -128,8 +136,15 @@ static char *parse_section(void) {
       synerr();
    }
 
+   ret = l->run + frontpos;
    l->run[rearpos] = '\0';
-   return l->run + frontpos;
+
+   if (STREQL(ret, SECTNAME_WILDCARD)) {
+      reason = "section name can't be *";
+      synerr();
+   }
+
+   return ret;
 }
 
 static int parse_value(array_t *sectarr) {

--- a/hhss/c/rtdbparse.h
+++ b/hhss/c/rtdbparse.h
@@ -12,6 +12,7 @@
  **************/
 array_t *rtdbparse(array_t *linestr);
 array_t *rtdbquery(array_t *table, const char *sectname);
+array_t *rtdbquerybyidx(array_t *table, size_t idx, const char **sectname);
 void rtdbcheck(array_t *db);
 void destroy_rtdb(array_t *rtdb);
 

--- a/hhss/dat.db
+++ b/hhss/dat.db
@@ -16,7 +16,7 @@ ${user|char}... 전혀 우마뾰이 하지 않아요
 ${world|clang|object}을(를) 좋아하는 건 ${user|char}뿐이냐
 ${user|char}라고 생각했던 ${user|char}와(과)의 신혼생활이 너무 잘 풀리는 건에 대하여
 내가 ${user|char}이(가) 될 수 있을 리 없잖아, 무리무리! (무리가 아니었다?!)
-내 현실과 온라인 게임이 ${user|char|world|object|emotion}에 침식당하기 시작해서 위험해
+내 현실과 온라인 게임이 ${*}에 침식당하기 시작해서 위험해
 너네, ${user|char}인 날 너무 좋아하는 거 아니냐.
 ${user|char|world|object}이(가) 인기 없는 건 아무리 생각해도 ${user|char}들 탓이야!
 ${user|char|emotion}을(를) 너무너무너무너무 좋아하는 100명의 ${user|char}


### PR DESCRIPTION
${*} resolves to the arbitrary sections in `rt.db`. Incidentally, it is valid to write like `${*|user|char}`.

closes #72.